### PR TITLE
Fix for Fatal error: Declaration of ShibbolethAuth::__construct

### DIFF
--- a/ShibbolethAuth.php
+++ b/ShibbolethAuth.php
@@ -51,7 +51,7 @@ class ShibbolethAuth extends AuthPluginBase {
         )
     );
 
-    public function __construct(PluginManager $manager, $id) {
+    public function __construct(\LimeSurvey\PluginManager\PluginManager $manager, $id) {
         parent::__construct($manager, $id);
 
         $this->subscribe('beforeLogin');


### PR DESCRIPTION
This commit fix the following error on limesurvey3.4.2+180223 
"Fatal error: Declaration of ShibbolethAuth::__construct(PluginManager $manager, $id) must be compatible with LimeSurvey\PluginManager\iPlugin::__construct(LimeSurvey\PluginManager\PluginManager $manager, $id)" 