### PR TITLE
Removed the user verification of the user type Shibboleth

### DIFF
--- a/ShibbolethAuth.php
+++ b/ShibbolethAuth.php
@@ -60,12 +60,15 @@ class ShibbolethAuth extends AuthPluginBase {
     }
 
     public function beforeLogin() {
-		// Do nothing if this user is not ShibbolethAuth type
+	    	// Doesn't return any value to $identity, it fails, always
+	    	// Do nothing if this user is not ShibbolethAuth type
+		/*
 		$identity = $this->getEvent()->get('identity');
 		if ($identity->plugin != 'ShibbolethAuth') 
 		{
 			return;
 		}
+		*/
 
 		$authuserid = $this->get('authuserid');
 		$authusergivenName = $this->get('authusergivenName');


### PR DESCRIPTION
Removed the user verification of the user type, $identity is always empty, it fails to proceed
(If you want to have multiple authentication type, you must find another way)